### PR TITLE
Blackboard + Gmail Compatibility

### DIFF
--- a/js/login.js
+++ b/js/login.js
@@ -1,21 +1,37 @@
 
 $(function() {
-	// Login sequence
-	loading();
-	chrome.storage.sync.get("username", function(obj) {
-		console.log(obj["username"]);
-		$("#username").val(obj["username"]);
-	});
-	chrome.storage.sync.get("password", function(obj) {
-		$("#password").focus();
-		$("#password").val(obj["password"]);
-		$('[name="pw"]').val(obj["password"]);
-		$('[name="theform"]').submit();
-	});
+    // Login sequence [shib.bu.edu, shib2.bu.edu]
+    if (["shib.bu.edu", "shib2.bu.edu"].includes(window.location.hostname)) {
+        loading("form");
+        chrome.storage.sync.get("username", function(obj) {
+            document.getElementById('j_username').value = obj["username"];
+        });
+        chrome.storage.sync.get("password", function(obj) {
+            document.getElementById('j_password').value = obj["password"];
+            if (window.location.hostname === "shib2.bu.edu") {
+                $(".input-submit").click();
+            } else {
+                $("button").click();
+            }
+        });
+        return;
+    }
+    // Login sequence [weblogin.bu.edu]
+    loading('[name="theform"]');
+    chrome.storage.sync.get("username", function(obj) {
+        console.log(obj["username"]);
+        $("#username").val(obj["username"]);
+    });
+    chrome.storage.sync.get("password", function(obj) {
+        $("#password").focus();
+        $("#password").val(obj["password"]);
+        $('[name="pw"]').val(obj["password"]);
+        $('[name="theform"]').submit();
+    });
 });
 
-function loading() {
-	$('[name="theform"]').hide();
-	var path = chrome.extension.getURL('/img/loading.svg');
-	$('[name="theform"]').after(`<h2>Logging you in...</h2><div style='margin: auto;'><img src='${path}'></img></div>`);
+function loading(selector) {
+    $(selector).hide();
+    var path = chrome.extension.getURL('/img/loading.svg');
+    $(selector).after(`<h2>Logging you in...</h2><div style='margin: auto;'><img src='${path}'></img></div>`);
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,37 +1,37 @@
 
 {
-	"name": "BU Kerberos AutoLogin",
-	"short_name": "AutoLogin",
-	"description" : "Automatically logs you into BU Kerberos.",
-	"version": "1.0.1",
-	"content_scripts": [
-    	{
-			"matches": ["https://weblogin.bu.edu/*"],
-			"js": ["js/jquery.js", "js/login.js"]
-    	}
-  	],
-  	"background": {
-  		"scripts": ["js/block.js"]
-  	},
-  	"permissions": [
-  		"webRequest",
-  		"webRequestBlocking",
-  		"https://weblogin.bu.edu/lib/scripts/BUweblogin.js",
-  		"storage"
-  	],
-  	"web_accessible_resources": [
-    	"img/loading.svg"
-	],
-	"browser_action": {
-		"default_title": "BU Kerberos AutoLogin",
-		"default_icon": "img/lock_16x16.png",
-		"default_popup": "popup.html"
-	},
-	"icons": {
-		"16": "img/lock_16x16.png",
-		"48": "img/lock_48x48.png",
-		"128": "img/lock_128x128.png"
-	},
-	"content_security_policy": "script-src 'self' https://ssl.google-analytics.com; object-src 'self'",
-	"manifest_version": 2
+    "name": "BU Kerberos AutoLogin",
+    "short_name": "AutoLogin",
+    "description" : "Automatically logs you into BU Kerberos.",
+    "version": "1.0.1",
+    "content_scripts": [
+        {
+            "matches": ["https://weblogin.bu.edu/*", "https://shib.bu.edu/*", "https://shib2.bu.edu/*"],
+            "js": ["js/jquery.js", "js/login.js"]
+        }
+    ],
+    "background": {
+        "scripts": ["js/block.js"]
+    },
+    "permissions": [
+        "webRequest",
+        "webRequestBlocking",
+        "https://weblogin.bu.edu/lib/scripts/BUweblogin.js",
+        "storage"
+    ],
+    "web_accessible_resources": [
+        "img/loading.svg"
+    ],
+    "browser_action": {
+        "default_title": "BU Kerberos AutoLogin",
+        "default_icon": "img/lock_16x16.png",
+        "default_popup": "popup.html"
+    },
+    "icons": {
+        "16": "img/lock_16x16.png",
+        "48": "img/lock_48x48.png",
+        "128": "img/lock_128x128.png"
+    },
+    "content_security_policy": "script-src 'self' https://ssl.google-analytics.com; object-src 'self'",
+    "manifest_version": 2
 }


### PR DESCRIPTION
This adds compatibility for the authentication domains of https://shib.bu.edu and https://shib2.bu.edu which are used for the BU authentication in BU's Gmail and Blackboard accounts.